### PR TITLE
Vuetifyのスタイルを上書き(markdown記法でコードブロックの表示が崩れていた)

### DIFF
--- a/docs/.vuepress/theme/enhanceApp.js
+++ b/docs/.vuepress/theme/enhanceApp.js
@@ -1,6 +1,7 @@
 import Vuetify from '../../../node_modules/vuetify'
 import '../../../node_modules/vuetify/dist/vuetify.min.css'
 import '../../../node_modules/@mdi/font/css/materialdesignicons.css'
+import './styles/override-vuetify.styl'
 
 export default ({
   Vue,

--- a/docs/.vuepress/theme/styles/override-vuetify.styl
+++ b/docs/.vuepress/theme/styles/override-vuetify.styl
@@ -1,0 +1,35 @@
+code,
+kbd,
+pre,
+samp {
+  font-family: initial;
+}
+
+code,
+kbd {
+  display: initial;
+  border-radius: initial;
+  // white-space: initial;
+  font-size: initial;
+  font-weight: initial;
+}
+code:after,
+kbd:after,
+code:before,
+kbd:before {
+  content: initial;
+  letter-spacing: initial;
+}
+code {
+  background-color: initial;
+  color: initial;
+  box-shadow: initial;
+}
+kbd {
+  background: initial;
+  color: initial;
+}
+
+code, kbd, .line-number{
+  font-family source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace
+}


### PR DESCRIPTION
暫定的に対応。